### PR TITLE
`Command` requires an array now

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,20 @@ The `bake` is a simple task runner. The tasks can be defined in a toml file.
 dependencies = ["build"]
 
 [ls]
-command = "ls"
+command = ["ls"]
 
 [test]
-command = "go"
-args = ["test", "-v"]
+command = ["go", "test", "-v"]
 
 [clean]
-command = "go"
-args = ["clean"]
+command = ["go", "clean"]
 
 [build]
-command = "go"
-args = ["build"]
+command = ["go", "build"]
 dependencies = ["clean"]
 
 [lint]
-command = "golangci-lint"
-args = ["run", "--disable", "errcheck"]
+command = ["golangci-lint", "run", "--disable", "errcheck"]
 
 [all]
 dependencies = ["lint", "test", "build"]
@@ -72,10 +68,9 @@ If you want to switch a command according to OS, you can branch a command inside
 ```
 [chrome]
 {{if eq .OS "windows"}}
-command = "start"
-args = ["chrome"]
+command = ["start", "chrome"]
 {{else}}
-command = "google-chrome"
+command = ["google-chrome"]
 {{end}}
 ```
 
@@ -87,8 +82,7 @@ You can define variables inside a configuration file.
 {{$binary:="dummy"}}
 
 [build]
-command = "go"
-args = ["build", "-o", "{{$binary}}"]
+command = ["go", "build", "-o", "{{$binary}}"]
 ```
 
 ## Installation

--- a/main.go
+++ b/main.go
@@ -20,8 +20,7 @@ const cmd = "bake"
 
 // Task represents a whole task.
 type Task struct {
-	Command      string
-	Args         []string
+	Command      []string
 	Commands     [][]string
 	Dependencies []string
 	Environments []string
@@ -179,12 +178,12 @@ func buildCommands(task Task, tasks map[string]Task) ([]Command, error) {
 		definedTasks[dependency] = true
 
 		if len(t.Command) > 0 {
-			commands = append(commands, Command{name: t.Command, args: t.Args, envs: t.Environments})
+			commands = append(commands, Command{name: t.Command[0], args: t.Command[1:], envs: t.Environments})
 		}
 	}
 
 	if len(task.Command) > 0 {
-		commands = append(commands, Command{name: task.Command, args: task.Args, envs: task.Environments})
+		commands = append(commands, Command{name: task.Command[0], args: task.Command[1:], envs: task.Environments})
 	}
 
 	if len(task.Commands) > 0 {
@@ -229,9 +228,13 @@ func showTasks(stdout io.Writer, tasks map[string]Task) {
 
 	for _, k := range keys {
 		cmd := tasks[k].Command
+		args := ""
 		if len(cmd) == 0 {
-			cmd = "*no command*"
+			cmd = []string{"*no command*"}
 		}
-		fmt.Fprintf(stdout, "[%s] %s %s\n", k, cmd, strings.Join(tasks[k].Args, " "))
+		if len(cmd[1:]) > 0 {
+			args = strings.Join(tasks[k].Command[1:], " ")
+		}
+		fmt.Fprintf(stdout, "[%s] %s %s\n", k, cmd[0], args)
 	}
 }

--- a/testdata/sample.toml
+++ b/testdata/sample.toml
@@ -2,57 +2,48 @@
 dependencies = ["build"]
 
 [ls]
-command = "ls"
+command = ["ls"]
 
 [test]
-command = "echo"
-args = ["test", "-v"]
+command = ["echo", "test", "-v"]
 
 [clean]
-command = "echo"
-args = ["clean"]
+command = ["echo", "clean"]
 
 [build]
-command = "echo"
-args = ["build"]
+command = ["echo", "build"]
 dependencies = ["clean"]
 
 [success]
-command = "echo"
-args = ["success"]
+command = ["echo", "success"]
 dependencies = ["fail"]
 
 [fail]
-command = "zzz"
+command = ["zzz"]
 
 [not_defined]
-command = "echo"
-args = ["not_defined"]
+command = ["echo", "not_defined"]
 dependencies = ["not_defined_dependency"]
 
 [self]
-command = "echo"
-args = ["self"]
+command = ["echo", "self"]
 dependencies = ["self"]
 
 [chrome]
 {{if eq .OS "windows"}}
-command = "echo"
-args = ["chrome"]
+command = ["echo", "chrome"]
 {{else}}
-command = "echo"
-args = ["google-chrome"]
+command = ["echo", "google-chrome"]
 {{end}}
 
 [lint]
-command = "golangci-lint"
-args = ["run", "--disable", "errcheck"]
+command = ["golangci-lint", "run", "--disable", "errcheck"]
 
 [all]
 dependencies = ["lint", "test", "build"]
 
 [env]
-command = "env"
+command = ["env"]
 environments = ["FOO=BAR"]
 
 [echos]


### PR DESCRIPTION
For making `Command` and `Commands` format to same.